### PR TITLE
remove async from google api script inclusion

### DIFF
--- a/index.html
+++ b/index.html
@@ -85,7 +85,7 @@
     <script src="https://code.jquery.com/jquery-3.7.1.min.js"
         integrity="sha256-/JqT3SQfawRcv/BIHPThkBvs0OEvtFFmqPF/lYI/Cxo=" crossorigin="anonymous"></script>
 
-    <script async defer
+    <script defer
         src="https://maps.googleapis.com/maps/api/js?key=AIzaSyCFTg8yxhfKfqvVhtZpfmTyXco9qlHLm2Q&libraries=places&callback=initGoogle">
         </script>
 

--- a/restaurant-details.html
+++ b/restaurant-details.html
@@ -90,7 +90,7 @@
 
     <script src="https://code.jquery.com/jquery-3.7.1.min.js"
         integrity="sha256-/JqT3SQfawRcv/BIHPThkBvs0OEvtFFmqPF/lYI/Cxo=" crossorigin="anonymous"></script>
-    <script async defer
+    <script defer
         src="https://maps.googleapis.com/maps/api/js?key=AIzaSyCFTg8yxhfKfqvVhtZpfmTyXco9qlHLm2Q&libraries=places&callback=initPlaces">
     </script>
     <script src="./assets/js/query-search.js"></script>


### PR DESCRIPTION
- leaving it only with "defer" makes the "initGoogle() doesn't exist" error go away, but the api calls still work