### PR TITLE
remove default bounds tends to show more accuracy

### DIFF
--- a/assets/js/query-search.js
+++ b/assets/js/query-search.js
@@ -252,15 +252,15 @@ function initGoogle() {
  */
 function initAutocomplete() {
     // Create a bounding box with sides ~10km away from the center point
-    const defaultBounds = {
-        north: deviceLocation.lat + 0.1,
-        south: deviceLocation.lat - 0.1,
-        east: deviceLocation.lng + 0.1,
-        west: deviceLocation.lng - 0.1,
-    };
+    // const defaultBounds = {
+    //     north: deviceLocation.lat + 0.1,
+    //     south: deviceLocation.lat - 0.1,
+    //     east: deviceLocation.lng + 0.1,
+    //     west: deviceLocation.lng - 0.1,
+    // };
 
     const options = {
-        bounds: defaultBounds,
+        // bounds: defaultBounds,
         types: ["(cities)"],
         fields: ["geometry"],
     }


### PR DESCRIPTION
- not having a gps coordinate bounding box allows for more accurate location finding for some reason.
- Even not sharing your location with the browser still let's the autocomplete api to work well